### PR TITLE
Make types constants inlineable by perl

### DIFF
--- a/lib/FFI/Raw.pm
+++ b/lib/FFI/Raw.pm
@@ -90,7 +90,7 @@ Return a C<FFI::Raw> void type.
 
 =cut
 
-sub void   { ord 'v' };
+sub void ()  { ord 'v' }
 
 =head2 FFI::Raw::int
 
@@ -98,7 +98,7 @@ Return a C<FFI::Raw> integer type.
 
 =cut
 
-sub int    { ord 'i' };
+sub int ()   { ord 'i' }
 
 =head2 FFI::Raw::uint
 
@@ -106,7 +106,7 @@ Return a C<FFI::Raw> unsigned integer type.
 
 =cut
 
-sub uint    { ord 'I' };
+sub uint ()   { ord 'I' }
 
 =head2 FFI::Raw::short
 
@@ -114,7 +114,7 @@ Return a C<FFI::Raw> short integer type.
 
 =cut
 
-sub short    { ord 'z' };
+sub short ()   { ord 'z' }
 
 =head2 FFI::Raw::ushort
 
@@ -122,7 +122,7 @@ Return a C<FFI::Raw> unsigned short integer type.
 
 =cut
 
-sub ushort    { ord 'Z' };
+sub ushort ()   { ord 'Z' }
 
 =head2 FFI::Raw::char
 
@@ -130,7 +130,7 @@ Return a C<FFI::Raw> char type.
 
 =cut
 
-sub char   { ord 'c' };
+sub char ()  { ord 'c' }
 
 =head2 FFI::Raw::uchar
 
@@ -138,7 +138,7 @@ Return a C<FFI::Raw> unsigned char type.
 
 =cut
 
-sub uchar   { ord 'C' };
+sub uchar ()  { ord 'C' }
 
 =head2 FFI::Raw::float
 
@@ -146,7 +146,7 @@ Return a C<FFI::Raw> float type.
 
 =cut
 
-sub float  { ord 'f' };
+sub float () { ord 'f' }
 
 =head2 FFI::Raw::double
 
@@ -154,7 +154,7 @@ Return a C<FFI::Raw> double type.
 
 =cut
 
-sub double { ord 'd' };
+sub double () { ord 'd' }
 
 =head2 FFI::Raw::str
 
@@ -162,7 +162,7 @@ Return a C<FFI::Raw> string type.
 
 =cut
 
-sub str    { ord 's' };
+sub str ()   { ord 's' }
 
 =head2 FFI::Raw::ptr
 
@@ -170,7 +170,7 @@ Return a C<FFI::Raw> pointer type.
 
 =cut
 
-sub ptr    { ord 'p' };
+sub ptr ()   { ord 'p' }
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Add prototype to types constants to make them inlinable at compile
time.
