### PR TITLE
add cpanm --notest option to speed up travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ perl:
 
 install:
  - sudo apt-get install libffi-dev
- - cpanm Dist::Zilla Dist::Zilla::PluginBundle::Author::ALEXBIO Devel::CheckLib
- - dzil listdeps --missing | cpanm
+ - cpanm --notest Dist::Zilla Dist::Zilla::PluginBundle::Author::ALEXBIO Devel::CheckLib
+ - dzil listdeps --missing | cpanm --notest
 
 script:
  - dzil test


### PR DESCRIPTION
after submitting pull request #9 noticed your travis tests can take awhile (~10min), this should speed things up
