### PR TITLE
t/02-simple-args.c: remove extraneous variable in printf

### DIFF
--- a/t/02-simple-args.c
+++ b/t/02-simple-args.c
@@ -40,60 +40,60 @@ extern void take_one_uint64(uint64_t x) {
 
 extern void take_one_int(int x) {
 	if (x == 42)
-		printf("ok - got passed int 42\n", x);
+		printf("ok - got passed int 42\n");
 	else
-		printf("not ok - got passed int 42\n", x);
+		printf("not ok - got passed int 42\n");
 
 	fflush(stdout);
 }
 
 extern void take_two_shorts(short x, short y) {
 	if (x == 10)
-		printf("ok - got passed short 10\n", x);
+		printf("ok - got passed short 10\n");
 	else
-		printf("not ok - got passed short 10\n", x);
+		printf("not ok - got passed short 10\n");
 
 	if (y == 20)
-		printf("ok - got passed short 20\n", x);
+		printf("ok - got passed short 20\n");
 	else
-		printf("not ok - got passed short 20\n", x);
+		printf("not ok - got passed short 20\n");
 
 	fflush(stdout);
 }
 
 extern void take_misc_ints(int x, short y, char z) {
 	if (x == 101)
-		printf("ok - got passed int 101\n", x);
+		printf("ok - got passed int 101\n");
 	else
-		printf("not ok - got passed int 101\n", x);
+		printf("not ok - got passed int 101\n");
 
 	if (y == 102)
-		printf("ok - got passed short 102\n", x);
+		printf("ok - got passed short 102\n");
 	else
-		printf("not ok - got passed short 102\n", x);
+		printf("not ok - got passed short 102\n");
 
 	if (z == 103)
-		printf("ok - got passed char 103\n", x);
+		printf("ok - got passed char 103\n");
 	else
-		printf("not ok - got passed char 103\n", x);
+		printf("not ok - got passed char 103\n");
 
 	fflush(stdout);
 }
 
 extern void take_one_double(double x) {
 	if (-6.9 - x < 0.001)
-		printf("ok - got passed double -6.9\n", x);
+		printf("ok - got passed double -6.9\n");
 	else
-		printf("not ok - got passed double -6.9\n", x);
+		printf("not ok - got passed double -6.9\n");
 
 	fflush(stdout);
 }
 
 extern void take_one_float(float x) {
 	if (4.2 - x < 0.001)
-		printf("ok - got passed float 4.2\n", x);
+		printf("ok - got passed float 4.2\n");
 	else
-		printf("not ok - got passed float 4.2\n", x);
+		printf("not ok - got passed float 4.2\n");
 
 	fflush(stdout);
 }


### PR DESCRIPTION
Hi @ghedo, just a small patch fixing some compiler warnings I noticed when installing FFI::Raw:

<pre>
calid@fedora32 (cc-warn-fix ?) /home/calid/git/p5-FFI-Raw/FFI-Raw-0.20
✔ make test
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00-compile.t .............. ok
t/01-argless.t .............. ok
t/02-simple-args.t .......... ./t/02-simple-args.c: In function ‘take_one_int’:
./t/02-simple-args.c:43:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed int 42\n", x);
   ^
./t/02-simple-args.c:45:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed int 42\n", x);
   ^
./t/02-simple-args.c: In function ‘take_two_shorts’:
./t/02-simple-args.c:52:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed short 10\n", x);
   ^
./t/02-simple-args.c:54:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed short 10\n", x);
   ^
./t/02-simple-args.c:57:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed short 20\n", x);
   ^
./t/02-simple-args.c:59:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed short 20\n", x);
   ^
./t/02-simple-args.c: In function ‘take_misc_ints’:
./t/02-simple-args.c:66:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed int 101\n", x);
   ^
./t/02-simple-args.c:68:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed int 101\n", x);
   ^
./t/02-simple-args.c:71:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed short 102\n", x);
   ^
./t/02-simple-args.c:73:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed short 102\n", x);
   ^
./t/02-simple-args.c:76:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed char 103\n", x);
   ^
./t/02-simple-args.c:78:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed char 103\n", x);
   ^
./t/02-simple-args.c: In function ‘take_one_double’:
./t/02-simple-args.c:85:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed double -6.9\n", x);
   ^
./t/02-simple-args.c:87:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed double -6.9\n", x);
   ^
./t/02-simple-args.c: In function ‘take_one_float’:
./t/02-simple-args.c:94:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("ok - got passed float 4.2\n", x);
   ^
./t/02-simple-args.c:96:3: warning: too many arguments for format [-Wformat-extra-args]
   printf("not ok - got passed float 4.2\n", x);
   ^
...
</pre>
