### PR TITLE
MemPtr::tostr() newSVpvn() instead of newSVpm()

### DIFF
--- a/t/08-memptr.t
+++ b/t/08-memptr.t
@@ -1,0 +1,22 @@
+#!perl
+
+use Test::More;
+use FFI::Raw;
+
+my $greeting = "Hello\0World";
+
+my $buf = FFI::Raw::MemPtr -> new_from_buf($greeting, length $greeting);
+
+my $got = $buf -> tostr;
+
+is $got, "Hello", "Without arguments, tostr uses strlen() to determine the length";
+
+$got = $buf -> tostr(length $greeting);
+
+is $got, $greeting, "A length to tostr() is honoured, and binary data is retrieved correctly";
+
+$got = $buf -> tostr(0);
+
+is $got, '', "A length of 0 tostr() is handled correctly, returning an empty string";
+
+done_testing;

--- a/xs/MemPtr.xs
+++ b/xs/MemPtr.xs
@@ -52,7 +52,7 @@ tostr(self, ...)
 				break;
 
 			case 2:
-				RETVAL = newSVpv(self, SvUV(ST(1)));
+				RETVAL = newSVpvn(self, SvUV(ST(1)));
 				break;
 
 			default: Perl_croak(aTHX_ "Wrong number of arguments");


### PR DESCRIPTION
Hi ghedo!

Thank You for creating FFI::Raw! It is excellent work that we want to depend on with our modules.

Unfortunately we have discovered a Problem in ::MemPtr::tostr():

FFI::Raw::MemPtr::tostr() should use newSVpvn(), not newSVpv(), when a length
argument is supplied. Otherwise a length argument of 0 is treated by newSVpv()
as an instruction to use strlen() to find the length, not as a length of 0.

You can see another actual 'live' Problem of the newSVpv() call in this test https://github.com/klaus/zmq-ffi/blob/e9414a2e9fe9320ce4fb758b830b1faf2aa43444/t/router-req.t of the ZMQ::FFI module that depends on FFI::Raw.

Please consider applying this patch!

Thank You,

klaus
