### PR TITLE
export symbols for dll

### DIFF
--- a/t/09-opaque.c
+++ b/t/09-opaque.c
@@ -4,28 +4,28 @@
 
 struct foo { int bar; };
 
-struct foo *foo_new() {
+EXPORT struct foo *foo_new() {
 	struct foo *self;
 	self = malloc(sizeof(struct foo));
 	self->bar = 0;
 	return self;
 }
 
-int foo_get_bar(struct foo *self) {
+EXPORT int foo_get_bar(struct foo *self) {
 	return self->bar;
 }
 
-void foo_set_bar(struct foo *self, int bar) {
+EXPORT void foo_set_bar(struct foo *self, int bar) {
 	self->bar = bar;
 }
 
 static int free_count = 0;
 
-void foo_free(struct foo *self) {
+EXPORT void foo_free(struct foo *self) {
 	free_count++;
 	free(self);
 }
 
-int get_free_count(const char *class) {
+EXPORT int get_free_count(const char *class) {
 	return free_count;
 }


### PR DESCRIPTION
This fixes t/09-opaque.t with the native MS compiler.

This was my bad, I wrote this test after getting FFI::Raw to work with Visual C++ and then immediately broke it again by writing an unrelated test and not testing it on with Visual C++.
