### PR TITLE
fix for openbsd non-threaded Perl

### DIFF
--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -43,6 +43,10 @@ if ($^O eq 'MSWin32' && $Config{cc} =~ /cl(\.exe)?$/) {
   $WriteMakefileArgs{CCFLAGS} = "$Config::Config{ccflags} -DFFI_BUILDING",
 }
 
+if ($^O eq 'openbsd' && !$Config{usethreads}) {
+  $WriteMakefileArgs{MYEXTLIB} .= ' /usr/lib/libpthread.a';
+}
+
 EXTRA
 };
 
@@ -51,7 +55,6 @@ override _build_WriteMakefile_args => sub {
 	return +{
 		%{ super() },
 		INC	=> '-I. -Ixs -Ixs/libffi/include',
-		LIBS	=> '-lpthread',
 		OBJECT	=> '$(O_FILES) xs/libffi/.libs/libffi.a',
 		MYEXTLIB => 'xs/libffi/.libs/libffi.a',
 	}


### PR DESCRIPTION
With this patch I was able to get FFI::Raw to build and test correctly with an unthreaded perl on OpenBSD.  I also tested it with a threaded Perl on the same machine.
