### PR TITLE
Raw.xs: cleanup clang warning

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -222,12 +222,12 @@ new(class, library, function, ret_type, ...)
 		ffi_raw -> handle = dlopen(library_name, RTLD_LAZY);
 
 		if ((error = dlerror()) != NULL)
-			Perl_croak(aTHX_ error);
+			Perl_croak(aTHX_ "%s", error);
 
 		ffi_raw -> fn = dlsym(ffi_raw -> handle, function_name);
 
 		if ((error = dlerror()) != NULL)
-			Perl_croak(aTHX_ error);
+			Perl_croak(aTHX_ "%s", error);
 #endif
 		INIT_FFI_CIF(ffi_raw, 4)
 


### PR DESCRIPTION
This fixes these warnings produced by clang:

```
clang -c  -I. -Ixs -Ixs/libffi/include -fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2   -DVERSION=\"0.26\" -DXS_VERSION=\"0.26\" -fPIC "-I/home/ollisg/perl5/perlbrew/perls/perl-5.18.2c/lib/5.18.2/x86_64-linux/CORE"   Raw.c
Raw.xs:225:21: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                        Perl_croak(aTHX_ error);
                                         ^~~~~
Raw.xs:230:21: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                        Perl_croak(aTHX_ error);
                                         ^~~~~
2 warnings generated.
```
