### PR TITLE
skip int64 tests if LLONG constants not available

### DIFF
--- a/t/02-simple-args.c
+++ b/t/02-simple-args.c
@@ -23,6 +23,7 @@ extern EXPORT void take_one_ulong(unsigned long x) {
 	fflush(stdout);
 }
 
+#ifdef LLONG_MIN
 extern EXPORT void take_one_int64(int64_t x) {
 	if (x == LLONG_MIN)
 		printf("ok - got passed int64 %" PRId64 "\n", x);
@@ -31,7 +32,9 @@ extern EXPORT void take_one_int64(int64_t x) {
 
 	fflush(stdout);
 }
+#endif
 
+#ifdef ULLONG_MAX
 extern EXPORT void take_one_uint64(uint64_t x) {
 	if (x == ULLONG_MAX)
 		printf("ok - got passed uint64 %" PRIu64 "\n", x);
@@ -40,6 +43,7 @@ extern EXPORT void take_one_uint64(uint64_t x) {
 
 	fflush(stdout);
 }
+#endif
 
 extern EXPORT void take_one_int(int x) {
 	if (x == 42)

--- a/t/02-simple-args.t
+++ b/t/02-simple-args.t
@@ -29,10 +29,16 @@ if ($@) {
 	last SKIP;
 }
 
-my $take_one_int64 = FFI::Raw -> new(
+my $take_one_int64 = eval { FFI::Raw -> new(
 	$shared, 'take_one_int64',
 	FFI::Raw::void, FFI::Raw::int64
-);
+) };
+
+if ($@) {
+	print "# LLONG_MIN and ULLONG_MAX required for int64 tests\n";
+	$tests -= 2;
+	last SKIP;
+}
 
 $take_one_int64 -> call($min_int64);
 

--- a/t/03-simple-returns.c
+++ b/t/03-simple-returns.c
@@ -11,13 +11,17 @@ extern EXPORT unsigned long return_ulong() {
 	return ULONG_MAX;
 }
 
+#ifdef LLONG_MIN
 extern EXPORT int64_t return_int64() {
 	return LLONG_MIN;
 }
+#endif
 
+#ifdef ULLONG_MAX
 extern EXPORT uint64_t return_uint64() {
 	return ULLONG_MAX;
 }
+#endif
 
 extern EXPORT int return_int() {
 	return 101;

--- a/t/03-simple-returns.t
+++ b/t/03-simple-returns.t
@@ -23,7 +23,10 @@ eval "use Math::Int64";
 
 skip 'Math::Int64 required for int64 tests', 4 if $@;
 
-my $return_int64 = FFI::Raw -> new($shared, 'return_int64', FFI::Raw::int64);
+my $return_int64 = eval { FFI::Raw -> new($shared, 'return_int64', FFI::Raw::int64) };
+
+skip 'LLONG_MIN and ULLONG_MAX required for int64 tests', 4 if $@;
+
 is $return_int64 -> call, $min_int64->bstr();
 is $return_int64 -> (), $min_int64->bstr();
 


### PR DESCRIPTION
This should fix failures such as this:

http://www.cpantesters.org/cpan/report/834bdfd0-8c28-11e3-b56e-1ac18706f0e4
