### PR TITLE
MakeMaker.pm: optionally ExtUtils::PkgConfig to detect system libffi

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,9 @@ Math::Int64 = 0
 [Prereqs / ConfigureRequires]
 Devel::CheckLib = 0
 
+[Prereqs / ConfigureRecommends]
+ExtUtils::PkgConfig = 0
+
 [=inc::MakeMaker / MakeMaker]
 
 [PruneFiles]


### PR DESCRIPTION
Use pkg-config if it is available.  This helps on cygwin (probably in other places) which puts its libffi headers in a non-standard place.
