### PR TITLE
handle absolute paths correctly on Cygwin

### DIFF
--- a/t/12-absolute-path.c
+++ b/t/12-absolute-path.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+#include "ffi_test.h"
+
+extern EXPORT int one() {
+	return 1;
+}

--- a/t/12-absolute-path.t
+++ b/t/12-absolute-path.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use FFI::Raw;
+use File::Spec;
+use lib 't';
+use CompileTest;
+use File::Basename qw( basename dirname );
+use Env qw( @PATH );
+use File::Temp qw( tempdir );
+use File::Copy qw( cp );
+
+my $test     = '12-absolute-path';
+my $source   = "./t/$test.c";
+my $shared   = CompileTest::compile($source);
+my $absolute = File::Spec->rel2abs($shared);
+
+my $one = FFI::Raw->new($absolute, 'one', FFI::Raw::int);
+is $one->(), 1, "absolute $absolute";
+
+SKIP: {
+  skip 'requires cygwin or MSWin32', 1
+    unless $^O =~ /^(cygwin|MSWin32)$/;
+  
+  my $tmp = tempdir( CLEANUP => 1 );
+  cp($absolute, File::Spec->catfile($tmp, 'foo.dll'));
+
+  push @PATH, $tmp;
+  my $one = FFI::Raw->new('foo.dll', 'one', FFI::Raw::int);
+
+  is $one->(), 1, "path $tmp/foo.dll";
+}
+
+done_testing;


### PR DESCRIPTION
In cygwin land there are POSIX and windows paths, LoadLibrary requires a windows path since it is not a cygwin function, but FFI::Raw->new should be able to handle a absolute POSIX path, so for Cygwin only  convert the POSIX path to windows before attempting LoadLibrary.
