### PR TITLE
MakeMaker.pm: use the 'system lib' for MSWin32 too

### DIFF
--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -27,11 +27,11 @@ if (!$use_system_ffi && eval { require ExtUtils::PkgConfig }) {
 }
 
 sub MY::postamble {
+  return if $use_system_ffi;
+
   if ($^O eq 'MSWin32') {
     return "\t$^X -MAlien::MSYS=msys_run -Minc::MSYSConfigure -e \"configure(); msys_run 'make'\"\n\n";
   }
-
-  return if $use_system_ffi;
 
   return <<'MAKE_LIBFFI';
 $(MYEXTLIB):


### PR DESCRIPTION
When I originally did the system lib check, I didn't consider that I would be using pkg-config on Windows, but I actually managed to get it to work (with PkgConfig), and this will save me a lot of time not having to run configure every time I need to run dzil test.
