### PR TITLE
Raw.xs: use little-endian code for MSWin32 (x86)

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -319,7 +319,7 @@ new_from_ptr(class, function, ret_type, ...)
 }
 
 
-#if __BYTE_ORDER == __BIG_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
 # define FFI_CALL(TYPE, FN) {			\
 	void *result;				\
 	void *original;                         \


### PR DESCRIPTION
Neither __BYTE_ORDER nor __BIG_ENDIAN seem to be defined on Windows, so it was selecting the big-endian path instead of the intended little-endian path.
