### PR TITLE
Callbacks that return str

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -58,7 +58,7 @@ typedef struct FFI_RAW_CALLBACK {
 	ffi_cif cif;
 	ffi_type *ret;
 	char ret_type;
-	const char *ret_value;
+	void *ret_value;
 	ffi_type **args;
 	char *args_types;
 	unsigned int argc;
@@ -206,7 +206,7 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 				*(char**) ret = strdup(SvPV_nolen(value));
 			else
 				*(char**) ret = NULL;
-			self -> ret_value = *(char**) ret;
+			self -> ret_value = *(void**) ret;
 			
 			break;
 		}

--- a/Raw.xs
+++ b/Raw.xs
@@ -196,7 +196,27 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 		case 'C': *(unsigned char *) ret = POPi; break;
 		case 'f': *(float *) ret = POPn; break;
 		case 'd': *(double *) ret = POPn; break;
-		case 's': Perl_croak(aTHX_ "Not supported");
+		case 's': {
+			SV *rv, *value;
+			
+			rv = POPs;
+
+			if(!SvROK(rv)) {
+				Perl_croak(aTHX_ "String return value must be returned as a reference for callback");
+				break;
+			}
+			
+			value = SvRV(rv);
+			
+			if(SvREFCNT(value) <= 2) {
+				Perl_croak(aTHX_ "Reference to string must not be anonymous for callback return value");
+				break;
+			}
+			
+			*(char**) ret = SvPV_nolen(value);
+			
+			break;
+		}
 		case 'p': Perl_croak(aTHX_ "Not supported");
 	}
 

--- a/Raw.xs
+++ b/Raw.xs
@@ -203,9 +203,10 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 			if (self -> ret_value != NULL)
 				Safefree(self -> ret_value);
 			if (SvOK(value))
-				self -> ret_value = *(char**) ret = strdup(SvPV_nolen(value));
+				*(char**) ret = strdup(SvPV_nolen(value));
 			else
-				self -> ret_value = *(char**) ret = NULL;
+				*(char**) ret = NULL;
+			self -> ret_value = *(char**) ret;
 			
 			break;
 		}

--- a/Raw.xs
+++ b/Raw.xs
@@ -208,6 +208,11 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 			
 			value = SvRV(rv);
 			
+			if (!SvOK(value)) {
+				*(char**) ret = NULL;
+				break;
+			}
+			
 			if(SvREFCNT(value) <= 2) {
 				Perl_croak(aTHX_ "Reference to string must not be anonymous for callback return value");
 				break;

--- a/Raw.xs
+++ b/Raw.xs
@@ -217,7 +217,24 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 			
 			break;
 		}
-		case 'p': Perl_croak(aTHX_ "Not supported");
+		case 'p': {
+			SV *value;
+			
+			value = POPs;
+			
+			if (!SvOK(value)) {
+				*(void**) ret = NULL;
+				break;
+			}
+			
+			if (sv_derived_from(value, "FFI::Raw::Ptr") || sv_derived_from(value, "FFI::Raw::Callback")) {
+				value = SvRV(value);
+			}
+
+			*(void**) ret = INT_TO_PTR(value);
+		
+			break;
+		}
 	}
 
 	PUTBACK;

--- a/Raw.xs
+++ b/Raw.xs
@@ -58,10 +58,10 @@ typedef struct FFI_RAW_CALLBACK {
 	ffi_cif cif;
 	ffi_type *ret;
 	char ret_type;
+	const char *ret_value;
 	ffi_type **args;
 	char *args_types;
 	unsigned int argc;
-	const char *string_value;
 } FFI_Raw_Callback_t;
 
 void *_ffi_raw_get_type(char type) {
@@ -200,12 +200,12 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 		case 's': {
 			SV *value = POPs;
 			
-			if (self -> string_value != NULL)
-				Safefree(self -> string_value);
+			if (self -> ret_value != NULL)
+				Safefree(self -> ret_value);
 			if (SvOK(value))
-				self -> string_value = *(char**) ret = strdup(SvPV_nolen(value));
+				self -> ret_value = *(char**) ret = strdup(SvPV_nolen(value));
 			else
-				self -> string_value = *(char**) ret = NULL;
+				self -> ret_value = *(char**) ret = NULL;
 			
 			break;
 		}

--- a/Raw.xs
+++ b/Raw.xs
@@ -203,7 +203,7 @@ void _ffi_raw_cb_wrap(ffi_cif *cif, void *ret, void *args[], void *argp) {
 			if (self -> ret_value != NULL)
 				Safefree(self -> ret_value);
 			if (SvOK(value))
-				*(char**) ret = strdup(SvPV_nolen(value));
+				*(char**) ret = savepv(SvPV_nolen(value));
 			else
 				*(char**) ret = NULL;
 			self -> ret_value = *(void**) ret;

--- a/lib/FFI/Raw/Callback.pm
+++ b/lib/FFI/Raw/Callback.pm
@@ -19,6 +19,14 @@ be passed to functions taking a C<FFI::Raw::ptr> type.
 Create a C<FFI::Raw::Callback> using the code reference C<$coderef> as body. The
 signature (return and arguments types) must also be passed.
 
+=head1 CAVEATS
+
+For callbacks with a C<FFI::Raw::str> return type, the string value will be copied 
+to a private field on the callback object.  The memory for this value will be
+freed the next time the callback is called, or when the callback itself is freed.
+For more exact control over when the return value is freed, you can instead
+use C<FFI::Raw::ptr> type and return a L<FFI::Raw::MemPtr> object.
+
 =head1 AUTHOR
 
 Alessandro Ghedini <alexbio@cpan.org>

--- a/t/05-callbacks.c
+++ b/t/05-callbacks.c
@@ -17,9 +17,18 @@ extern EXPORT int return_int_callback(int (*cb)(int)) {
 static char str_value[512] = "";
 
 extern EXPORT void return_str_callback(const char *(*cb)(void)) {
-	strcpy(str_value, cb());
+	const char *value = cb();
+	if(value == NULL) {
+		strcpy(str_value, "NULL");
+	} else {
+		strcpy(str_value, value);
+	}
 }
 
 extern EXPORT const char *get_str_value() {
 	return str_value;
+}
+
+extern EXPORT void reset() {
+	str_value[0] = '\0';
 }

--- a/t/05-callbacks.c
+++ b/t/05-callbacks.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 #include "ffi_test.h"
 
@@ -10,4 +11,15 @@ extern EXPORT void take_one_int_callback(void (*cb)(int)) {
 
 extern EXPORT int return_int_callback(int (*cb)(int)) {
 	return cb(42);
+}
+
+
+static char str_value[512] = "";
+
+extern EXPORT void return_str_callback(const char *(*cb)(void)) {
+	strcpy(str_value, cb());
+}
+
+extern EXPORT const char *get_str_value() {
+	return str_value;
 }

--- a/t/05-callbacks.t
+++ b/t/05-callbacks.t
@@ -93,6 +93,12 @@ eval { $return_str_callback -> call(FFI::Raw::callback(sub { \"foo" }, FFI::Raw:
 
 print ($@ =~ /Reference to string must not be anonymous for callback return value/ ? "ok\n" : "not ok - \$\@ = $@\n");
 
+my $reset = FFI::Raw -> new(
+	$shared, 'reset',
+	FFI::Raw::void,
+);
+
+$reset -> call();
 my $buffer = FFI::Raw::MemPtr->new_from_buf( "bar\0", length "bar\0" );
 my $cb5 = FFI::Raw::callback(sub { $buffer }, FFI::Raw::ptr);
 
@@ -104,4 +110,27 @@ $value = $get_str_value -> call();
 
 print ($value eq 'bar' ? "ok\n" : "not ok - returned $value\n");
 
-print "1..15\n";
+$reset -> call();
+my $buffer = FFI::Raw::MemPtr->new_from_buf( "baz\0", length "baz\0" );
+my $cb6 = FFI::Raw::callback(sub { $$buffer }, FFI::Raw::ptr);
+
+print "ok - survived the call\n";
+
+$return_str_callback -> call($cb6);
+
+$value = $get_str_value -> call();
+
+print ($value eq 'baz' ? "ok\n" : "not ok - returned $value\n");
+
+$reset -> call();
+my $cb7 = FFI::Raw::callback(sub { undef }, FFI::Raw::ptr);
+
+print "ok - survived the call\n";
+
+$return_str_callback -> call($cb7);
+
+$value = $get_str_value -> call();
+
+print ($value eq 'NULL' ? "ok\n" : "not ok - returned $value\n");
+
+print "1..19\n";

--- a/t/05-callbacks.t
+++ b/t/05-callbacks.t
@@ -65,7 +65,7 @@ print ($check1 == (42 + 15) ? "ok\n" : "not ok - returned $check1\n");
 print ($check2 == (42 + 15) ? "ok\n" : "not ok - returned $check2\n");
 
 my $str_value = \"foo";
-my $cb4 = FFI::Raw::callback(sub { $str_value }, FFI::Raw::str);
+my $cb4 = FFI::Raw::callback(sub { $$str_value }, FFI::Raw::str);
 
 print "ok - survived the call\n";
 
@@ -91,14 +91,6 @@ $return_str_callback->call($cb4);
 my $value = $get_str_value -> call();
 
 print ($value eq 'NULL' ? "ok\n" : "not ok - returned $value\n");
-
-eval { $return_str_callback -> call(FFI::Raw::callback(sub { "foo" }, FFI::Raw::str)) };
-
-print ($@ =~ /String return value must be returned as a reference for callback/ ? "ok\n" : "not ok - \$\@ = $@\n");
-
-eval { $return_str_callback -> call(FFI::Raw::callback(sub { \"foo" }, FFI::Raw::str)) };
-
-print ($@ =~ /Reference to string must not be anonymous for callback return value/ ? "ok\n" : "not ok - \$\@ = $@\n");
 
 my $reset = FFI::Raw -> new(
 	$shared, 'reset',
@@ -140,4 +132,4 @@ $value = $get_str_value -> call();
 
 print ($value eq 'NULL' ? "ok\n" : "not ok - returned $value\n");
 
-print "1..20\n";
+print "1..18\n";

--- a/t/05-callbacks.t
+++ b/t/05-callbacks.t
@@ -93,4 +93,15 @@ eval { $return_str_callback -> call(FFI::Raw::callback(sub { \"foo" }, FFI::Raw:
 
 print ($@ =~ /Reference to string must not be anonymous for callback return value/ ? "ok\n" : "not ok - \$\@ = $@\n");
 
-print "1..13\n";
+my $buffer = FFI::Raw::MemPtr->new_from_buf( "bar\0", length "bar\0" );
+my $cb5 = FFI::Raw::callback(sub { $buffer }, FFI::Raw::ptr);
+
+print "ok - survived the call\n";
+
+$return_str_callback -> call($cb5);
+
+$value = $get_str_value -> call();
+
+print ($value eq 'bar' ? "ok\n" : "not ok - returned $value\n");
+
+print "1..15\n";

--- a/t/05-callbacks.t
+++ b/t/05-callbacks.t
@@ -64,8 +64,8 @@ print "ok - survived the call (anonymous subroutine)\n";
 print ($check1 == (42 + 15) ? "ok\n" : "not ok - returned $check1\n");
 print ($check2 == (42 + 15) ? "ok\n" : "not ok - returned $check2\n");
 
-my $str_value = "foo";
-my $cb4 = FFI::Raw::callback(sub { \$str_value }, FFI::Raw::str);
+my $str_value = \"foo";
+my $cb4 = FFI::Raw::callback(sub { $str_value }, FFI::Raw::str);
 
 print "ok - survived the call\n";
 
@@ -84,6 +84,13 @@ my $get_str_value = FFI::Raw -> new(
 my $value = $get_str_value -> call();
 
 print ($value eq 'foo' ? "ok\n" : "not ok - returned $value\n");
+
+$str_value = \undef;
+$return_str_callback->call($cb4);
+
+my $value = $get_str_value -> call();
+
+print ($value eq 'NULL' ? "ok\n" : "not ok - returned $value\n");
 
 eval { $return_str_callback -> call(FFI::Raw::callback(sub { "foo" }, FFI::Raw::str)) };
 
@@ -133,4 +140,4 @@ $value = $get_str_value -> call();
 
 print ($value eq 'NULL' ? "ok\n" : "not ok - returned $value\n");
 
-print "1..19\n";
+print "1..20\n";

--- a/t/05-callbacks.t
+++ b/t/05-callbacks.t
@@ -64,4 +64,33 @@ print "ok - survived the call (anonymous subroutine)\n";
 print ($check1 == (42 + 15) ? "ok\n" : "not ok - returned $check1\n");
 print ($check2 == (42 + 15) ? "ok\n" : "not ok - returned $check2\n");
 
-print "1..9\n";
+my $str_value = "foo";
+my $cb4 = FFI::Raw::callback(sub { \$str_value }, FFI::Raw::str);
+
+print "ok - survived the call\n";
+
+my $return_str_callback = FFI::Raw -> new(
+	$shared, 'return_str_callback',
+	FFI::Raw::void, FFI::Raw::ptr
+);
+
+$return_str_callback -> call($cb4);
+
+my $get_str_value = FFI::Raw -> new(
+	$shared, 'get_str_value',
+	FFI::Raw::str,
+);
+
+my $value = $get_str_value -> call();
+
+print ($value eq 'foo' ? "ok\n" : "not ok - returned $value\n");
+
+eval { $return_str_callback -> call(FFI::Raw::callback(sub { "foo" }, FFI::Raw::str)) };
+
+print ($@ =~ /String return value must be returned as a reference for callback/ ? "ok\n" : "not ok - \$\@ = $@\n");
+
+eval { $return_str_callback -> call(FFI::Raw::callback(sub { \"foo" }, FFI::Raw::str)) };
+
+print ($@ =~ /Reference to string must not be anonymous for callback return value/ ? "ok\n" : "not ok - \$\@ = $@\n");
+
+print "1..13\n";

--- a/xs/Callback.xs
+++ b/xs/Callback.xs
@@ -15,6 +15,7 @@ new(class, coderef, ret_type, ...)
 		Newx(ffi_raw_cb, 1, FFI_Raw_Callback_t);
 
 		ffi_raw_cb -> coderef = SvREFCNT_inc(coderef);
+		ffi_raw_cb -> string_value = NULL;
 
 		ffi_raw_cb -> closure = ffi_closure_alloc(
 			sizeof(ffi_closure),
@@ -40,6 +41,8 @@ DESTROY(self)
 	CODE:
 		SvREFCNT_dec(self -> coderef);
 
+		if (self -> string_value != NULL)
+			Safefree(self -> string_value);
 		Safefree(self -> args_types);
 		Safefree(self -> args);
 		Safefree(self);

--- a/xs/Callback.xs
+++ b/xs/Callback.xs
@@ -15,7 +15,7 @@ new(class, coderef, ret_type, ...)
 		Newx(ffi_raw_cb, 1, FFI_Raw_Callback_t);
 
 		ffi_raw_cb -> coderef = SvREFCNT_inc(coderef);
-		ffi_raw_cb -> string_value = NULL;
+		ffi_raw_cb -> ret_value = NULL;
 
 		ffi_raw_cb -> closure = ffi_closure_alloc(
 			sizeof(ffi_closure),
@@ -41,8 +41,8 @@ DESTROY(self)
 	CODE:
 		SvREFCNT_dec(self -> coderef);
 
-		if (self -> string_value != NULL)
-			Safefree(self -> string_value);
+		if (self -> ret_value != NULL)
+			Safefree(self -> ret_value);
 		Safefree(self -> args_types);
 		Safefree(self -> args);
 		Safefree(self);


### PR DESCRIPTION
This should resolve #42

The only thing that I think is a little iffy here is that strings must be returned as references.  It is iffy because we don't require references to strings anywhere else (that I am aware of).  However, I think with appropriate documentation the usefulness of being able to return a string from a callback compensates its strangeness.

If strongly apposed to that then I can do a PR with just the pointer support.
