### PR TITLE
Raw.xs: avoid warnings when using undef to mean NULL

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -432,26 +432,24 @@ call(self, ...)
 
 					Newx(val, 1, void *);
 					
-					if (!SvOK(arg)) {
+					if (!SvOK(arg))
 						*val = NULL;
-						values[i] = val;
-						break;
+					else {
+						if (sv_derived_from(
+							arg, "FFI::Raw::Ptr"
+						)) {
+							arg = SvRV(arg);
+						}
+	
+						if (sv_derived_from(
+							arg, "FFI::Raw::Callback"
+						)) {
+							FFI_Raw_Callback_t *cb =
+								INT_TO_PTR(SvRV(arg));
+							*val = cb -> fn;
+						} else
+							*val = INT_TO_PTR(arg);
 					}
-
-					if (sv_derived_from(
-						arg, "FFI::Raw::Ptr"
-					)) {
-						arg = SvRV(arg);
-					}
-
-					if (sv_derived_from(
-						arg, "FFI::Raw::Callback"
-					)) {
-						FFI_Raw_Callback_t *cb =
-							INT_TO_PTR(SvRV(arg));
-						*val = cb -> fn;
-					} else
-						*val = INT_TO_PTR(arg);
 
 					values[i] = val;
 					break;

--- a/Raw.xs
+++ b/Raw.xs
@@ -431,6 +431,12 @@ call(self, ...)
 					void **val;
 
 					Newx(val, 1, void *);
+					
+					if (!SvOK(arg)) {
+						*val = NULL;
+						values[i] = val;
+						break;
+					}
 
 					if (sv_derived_from(
 						arg, "FFI::Raw::Ptr"
@@ -444,10 +450,8 @@ call(self, ...)
 						FFI_Raw_Callback_t *cb =
 							INT_TO_PTR(SvRV(arg));
 						*val = cb -> fn;
-					} else if (SvOK(arg))
+					} else
 						*val = INT_TO_PTR(arg);
-					else
-						*val = NULL;
 
 					values[i] = val;
 					break;


### PR DESCRIPTION
When use warnings is on (recommended :) I get warnings from the sv_derived_from call.  This fixes that.
