### PR TITLE
use PkgConfig to detect if available

### DIFF
--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -26,6 +26,23 @@ if (!$use_system_ffi && eval { require ExtUtils::PkgConfig }) {
   }
 }
 
+if (!$use_system_ffi && eval { require PkgConfig }) {
+  my $pkg = PkgConfig->find('libffi');
+  
+  unless ($pkg->errmsg) {
+    my %pkg_config = (
+      libs   => join(' ', $pkg->get_ldflags),
+	  cflags => join(' ', $pkg->get_cflags),
+    );
+    
+    if (check_lib(header => "ffi.h", LIBS => $pkg_config{libs}, INC => $pkg_config{cflags})) {
+      $use_system_ffi = 1;
+      $pkg_config = \%pkg_config;
+	  print "use system\n";
+    }
+  }
+}
+
 sub MY::postamble {
   return if $use_system_ffi;
 


### PR DESCRIPTION
While working on #47, I added support for PkgConfig, which is easier on windows (for me at least) to install than pkg-config so that Makefile.PL can find the "system" libffi.
