### PR TITLE
Alien::MSYS is not necessary when using system libffi

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -30,5 +30,3 @@ ExtUtils::PkgConfig = 0
 [PruneFiles]
 filename = README.pod
 
-[OSPrereqs / MSWin32]
-Alien::MSYS = 0

--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -89,6 +89,10 @@ if ($use_system_ffi) {
 
 $WriteMakefileArgs{LIBS} = "@libs" if @libs;
 
+if ( $^O eq 'MSWin32' && !$use_system_ffi ) {
+        $WriteMakefileArgs{PREREQ_PM}{'Alien::MSYS'} = '0';
+}
+
 EXTRA
 };
 


### PR DESCRIPTION
This should address #47

Tested on MSWin32, and verified that if Makefile.PL can find the system lib then it doesn't require `Alien::MSYS`, but if it can't then it does require `Alien::MSYS`

I also have a combined branch for both #48  and this one if you want to accept both.
