### PR TITLE
fix Visual C++ build

### DIFF
--- a/inc/MSYSConfigure.pm
+++ b/inc/MSYSConfigure.pm
@@ -24,7 +24,7 @@ sub main::configure {
 		copy('msvcc.sh', "$dir/msvcc.sh");
 		$ENV{PATH} = join($Config{path_sep}, $dir, $ENV{PATH});
 
-		$configure_args .= ' --enable-static --disable-shared';
+		$configure_args .= ' --enable-static --disable-shared LD=link CPP="cl -nologo -EP"';
 
 		if ($Config{archname} =~ /^MSWin32-x64/) {
 			$configure_args .= ' CC="msvcc.sh -m64"';


### PR DESCRIPTION
This used to work, but I think when the MSWin32 build got refactored, these variables got left out.  They are needed for a build on MSWin32 with Visual C++.

Thanks!
